### PR TITLE
Fix/functions return df

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.vscode
 
 # Spyder project settings
 .spyderproject

--- a/example_scripts/extract_meta_data.py
+++ b/example_scripts/extract_meta_data.py
@@ -1,6 +1,50 @@
 import argparse
 from pathlib import Path
+
 from simepy.extract_meta_data import extract_meta_data
+
+
+def main(
+    input_file,
+    run_output_file,
+    spec_output_file,
+    noise_output_file,
+    unit_output_file,
+    time_format,
+    object_name,
+    lineage_root,
+):
+    """
+    Extract scan info from mzml file using extract_scan_data().
+
+    Args:
+        input_file (PosixPath): path to input file
+        run_output_file (str/NoneType): path to run metadata output_file
+        spec_output_file (str/NoneType): path to spectrum metadata output_file
+        noise_output_file (str/NoneType): path to spectrum noise output_file
+        units_output_file (str/NoneType): path to instrument units output_file
+        time_format (str): string defining the time_format to format into
+        object_name (str/NoneType): string to be used as file identifier
+        lineage_root (str/NoneType): name of the root file associated to the one, from which metadata is queried
+    """
+    rmd_df, imu_df, smd_df, sn_df = extract_meta_data(
+        input_file=input_file,
+        time_format=time_format,
+        object_name=object_name,
+        lineage_root=lineage_root,
+    )
+
+    if run_output_file is not None:
+        rmd_df.to_csv(run_output_file, index=False)
+
+    if spec_output_file is not None:
+        smd_df.to_csv(spec_output_file, index=False)
+
+    if unit_output_file is not None:
+        imu_df.to_csv(unit_output_file, index=False)
+
+    if noise_output_file is not None:
+        sn_df.to_csv(noise_output_file, index=False)
 
 
 if __name__ == "__main__":
@@ -14,24 +58,28 @@ if __name__ == "__main__":
     parser.add_argument(
         "-ro",
         "--run_output_file",
+        type=lambda x: None if x == "None" else str(x),
         dest="run_output_file",
         help="run metadata output file",
     )
     parser.add_argument(
         "-so",
         "--spec_output_file",
+        type=lambda x: None if x == "None" else str(x),
         dest="spec_output_file",
         help="spectrum metadata output file",
     )
     parser.add_argument(
         "-sno",
         "--spec_noise_output_file",
+        type=lambda x: None if x == "None" else str(x),
         dest="spec_noise_output_file",
         help="spectrum noise output file",
     )
     parser.add_argument(
         "-iuo",
         "--instrument_unit_output_file",
+        type=lambda x: None if x == "None" else str(x),
         dest="instrument_unit_output_file",
         help="instrument unit output file",
     )
@@ -60,7 +108,7 @@ if __name__ == "__main__":
         args.object_name = Path(args.input_file).name
     if args.lineage_root is None:
         args.lineage_root = Path(args.input_file).resolve()
-    extract_meta_data(
+    main(
         input_file=args.input_file,
         run_output_file=args.run_output_file,
         spec_output_file=args.spec_output_file,

--- a/example_scripts/extract_scan_data.py
+++ b/example_scripts/extract_scan_data.py
@@ -1,5 +1,18 @@
 import argparse
+
 from simepy.extract_scans import extract_scan_data
+
+
+def main(input_file, output_file):
+    """
+    Extract scan info from mzml file using extract_scan_data().
+
+    Args:
+        input_file (PosixPath): path to input file
+        output_file (PosixPath): path to scans output file
+    """
+    scans_out = extract_scan_data(input_file)
+    scans_out.to_csv(output_file, index=False)
 
 
 if __name__ == "__main__":
@@ -18,4 +31,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    extract_scan_data(input_file=args.input_file, output_file=args.output_file)
+    main(input_file=args.input_file, output_file=args.output_file)

--- a/simepy/extract_scans.py
+++ b/simepy/extract_scans.py
@@ -6,16 +6,15 @@ import pandas as pd
 import pymzml
 
 
-def extract_scan_data(input_file, output_file):
+def extract_scan_data(input_file):
     """
     Extract scan info like mass, intensity, id and filename from an input mzml file.
 
     Args:
         input_file (PosixPath): path to input file
-        output_file (PosixPath): path to scans output file
 
     Returns:
-        None
+        scans_out (pandas.DataFrame): Dataframe containing scans information
     """
     logging.info("Starting scan info extraction!")
     with pymzml.run.Reader(str(input_file)) as reader:
@@ -30,6 +29,5 @@ def extract_scan_data(input_file, output_file):
             scans.append(scans_df)
 
     scans_out = pd.concat(scans)
-    scans_out.to_csv(output_file, index=False)
-
     logging.info("Scans info extraction completed!")
+    return scans_out

--- a/tests/test_spectrum_data.py
+++ b/tests/test_spectrum_data.py
@@ -1,7 +1,5 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 
-import pandas as pd
 import pytest
 
 from simepy.extract_meta_data import extract_meta_data
@@ -20,21 +18,9 @@ def test_extract_scans():
 def test_extract_meta_data_mzml():
     input_file = Path(__file__).parent / "data" / "BSA1.mzML"
 
-    with NamedTemporaryFile() as scans, NamedTemporaryFile() as run, NamedTemporaryFile() as noise, NamedTemporaryFile() as instrument:
-        extract_meta_data(
-            input_file=input_file,
-            run_output_file=run.name,
-            spec_output_file=scans.name,
-            noise_output_file=noise.name,
-            unit_output_file=instrument.name,
-            # object_name=args.object_name,
-            # lineage_root=args.lineage_root,
-        )
-
-        scans = pd.read_csv(scans.name)
-        run = pd.read_csv(run.name)
-        noise = pd.read_csv(noise.name)
-        instrument = pd.read_csv(instrument.name)
+    run, instrument, scans, noise = extract_meta_data(
+        input_file=input_file,
+    )
 
     assert scans["spectrum_id"].nunique() == 1684
     assert pytest.approx(scans["rt"].mean()) == 2037.37997769969

--- a/tests/test_spectrum_data.py
+++ b/tests/test_spectrum_data.py
@@ -1,18 +1,16 @@
 from pathlib import Path
-from simepy.extract_scans import extract_scan_data
-from simepy.extract_meta_data import extract_meta_data
-
 from tempfile import NamedTemporaryFile
+
 import pandas as pd
 import pytest
+
+from simepy.extract_meta_data import extract_meta_data
+from simepy.extract_scans import extract_scan_data
 
 
 def test_extract_scans():
     input_file = Path(__file__).parent / "data" / "BSA1.mzML"
-
-    with NamedTemporaryFile() as tmp_file:
-        extract_scan_data(input_file, tmp_file.name)
-        df = pd.read_csv(tmp_file.name)
+    df = extract_scan_data(input_file)
     assert df["filename"].nunique() == 1
     assert df["filename"].iloc[0] == "BSA1.mzML"
     assert df["spectrum_id"].nunique() == 1684


### PR DESCRIPTION
Updated the code base, such that the individual extraction functions return the data frames, whereas the example scripts write the output files! Had to replace the csv dict writer by pandas for that.

This is relevant, to be flexible and use the code also in a context where you don't want to handle IO, but simply pipe the data frames into the next code block.

In addition, the extract metadata code will extract the 4 different metadata frames, but will only write the ones out for which an output filename was provided.