### PR TITLE
Fix/obtain file suffix

### DIFF
--- a/simepy/extract_meta_data.py
+++ b/simepy/extract_meta_data.py
@@ -522,8 +522,8 @@ def get_file_type(input_file: Path) -> str:
     if isinstance(file_type, str):
         return file_type.lower()[1:]
     if isinstance(file_type, list):
-        if ".gz" in file_type:
-            return "".join(file_type).lower()[1:]
+        if file_type[-1] == ".gz" and len(file_type) > 1:
+            return "".join(file_type[-2:]).lower()[1:]
         else:
             return file_type[-1].lower()[1:]
     logging.error("Unknown suffix type, not str or list")

--- a/simepy/extract_meta_data.py
+++ b/simepy/extract_meta_data.py
@@ -560,7 +560,7 @@ def extract_meta_data(
     if lineage_root is None:
         lineage_root = Path(input_file).resolve().name
 
-    file_type = "".join(Path(input_file).suffixes).lower()[1:]
+    file_type = get_file_type(Path(input_file))
     logging.info(
         f"Identified file type is '{file_type}'. Proceeding with metadata extraction..."
     )
@@ -582,7 +582,7 @@ def extract_meta_data(
 
     # 2. InstrumentUnit
     gex_lookup = {}
-    if input_file.suffix.lower() == ".raw":
+    if file_type == "raw":
         imu_rows = []
         for unit_data_line in extract_data(
             input_file,
@@ -599,7 +599,7 @@ def extract_meta_data(
         imu_df = pd.concat(imu_rows, ignore_index=True)
         logging.info("Finished instrument unit info extraction!")
 
-    elif "".join(input_file.suffixes).lower() in [".mzml", ".mzml.gz"]:
+    elif file_type in ["mzml", "mzml.gz"]:
         imu_df = pd.DataFrame(
             [], columns=[x for x in InstrumentMetaUnit.schema()["properties"].keys()]
         )
@@ -622,7 +622,7 @@ def extract_meta_data(
     logging.info("Finished spectrum metadata info extraction!")
 
     # 4. SpectrumNoise
-    if input_file.suffix.lower() == ".raw":
+    if file_type == "raw":
         sn_rows = []
         for noise_data_line in extract_data(
             input_file,
@@ -638,7 +638,7 @@ def extract_meta_data(
         sn_df = pd.concat(sn_rows, ignore_index=True)
         logging.info("Finished spectrum noise extraction!")
 
-    elif "".join(input_file.suffixes).lower() in [".mzml", ".mzml.gz"]:
+    elif file_type in ["mzml", "mzml.gz"]:
         sn_df = pd.DataFrame(
             [], columns=[x for x in SpectrumNoise.schema()["properties"].keys()]
         )

--- a/simepy/extract_meta_data.py
+++ b/simepy/extract_meta_data.py
@@ -519,9 +519,9 @@ def get_file_type(input_file: Path) -> str:
         file_type: (str): string of the filetype
     """
     file_type = Path(input_file).suffixes
-    if type(file_type) is str:
+    if isinstance(file_type, str):
         return file_type.lower()[1:]
-    if type(file_type) is list:
+    if isinstance(file_type, list):
         if ".gz" in file_type:
             return "".join(file_type).lower()[1:]
         else:

--- a/simepy/extract_meta_data.py
+++ b/simepy/extract_meta_data.py
@@ -508,6 +508,28 @@ def extract_data(
         return extract_function(input_file, object_name, lineage_root, time_format)
 
 
+def get_file_type(input_file: Path) -> str:
+    """
+    Extract the filetype from the input file Path. Uses last suffix without '.' exept for gz files
+
+    Args:
+        input_file (PosixPath): path to ms data input file (mzml|raw|mgf)
+
+    Returns:
+        file_type: (str): string of the filetype
+    """
+    file_type = Path(input_file).suffixes
+    if type(file_type) is str:
+        return file_type.lower()[1:]
+    if type(file_type) is list:
+        if ".gz" in file_type:
+            return "".join(file_type).lower()[1:]
+        else:
+            return file_type[-1].lower()[1:]
+    logging.error("Unknown suffix type, not str or list")
+    raise TypeError
+
+
 def extract_meta_data(
     input_file,
     time_format="%Y-%m-%d %H:%M:%S",

--- a/tests/test_spectrum_data.py
+++ b/tests/test_spectrum_data.py
@@ -43,6 +43,9 @@ def test_extract_meta_data_raw():
         (Path("some_file.thermorawfile.mzml"), "mzml"),
         (Path("another_file.mzml.gz"), "mzml.gz"),
         (Path("one_more_file.raw"), "raw"),
+        (Path("one_more_file.with.many.suffixes.raw"), "raw"),
+        (Path("one_more_file.with.many.suffixes.mzml"), "mzml"),
+        (Path("one_more_file.with.many.suffixes.mzml.gz"), "mzml.gz"),
     ],
 )
 def test_get_file_type(path, file_type):

--- a/tests/test_spectrum_data.py
+++ b/tests/test_spectrum_data.py
@@ -38,13 +38,12 @@ def test_extract_meta_data_raw():
 
 
 @pytest.mark.parametrize(
-    "path",
+    "path,file_type",
     [
-        Path("some_file.thermorawfile.mzml"),
-        Path("another_file.mzml.gz"),
-        Path("one_more_file.raw"),
+        (Path("some_file.thermorawfile.mzml"), "mzml"),
+        (Path("another_file.mzml.gz"), "mzml.gz"),
+        (Path("one_more_file.raw"), "raw"),
     ],
 )
-@pytest.mark.parametrize("file_type", ["mzml", "mzml.gz", "raw"])
 def test_get_file_type(path, file_type):
     assert get_file_type(path) == file_type

--- a/tests/test_spectrum_data.py
+++ b/tests/test_spectrum_data.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from simepy.extract_meta_data import extract_meta_data
+from simepy.extract_meta_data import get_file_type
 from simepy.extract_scans import extract_scan_data
 
 
@@ -34,3 +35,16 @@ def test_extract_meta_data_mzml():
 
 def test_extract_meta_data_raw():
     pass
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        Path("some_file.thermorawfile.mzml"),
+        Path("another_file.mzml.gz"),
+        Path("one_more_file.raw"),
+    ],
+)
+@pytest.mark.parametrize("file_type", ["mzml", "mzml.gz", "raw"])
+def test_get_file_type(path, file_type):
+    assert get_file_type(path) == file_type


### PR DESCRIPTION
File suffixes were extracted incorrectly and with different methods for each "if" clause.
Bundeled extraction into one function, harmonized file type structure (".mzml" vs "mzml") and added tests.